### PR TITLE
OS + URL + URLSearchParams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,7 @@ ASALocalRun/
 yarn\.lock
 
 tests/test\.js
+
+build\.fsx\.lock
+
+package-lock\.json

--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,5 @@ ASALocalRun/
 .mfractor/
 
 yarn\.lock
+
+tests/test\.js

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 Fable bindings for [node.js native modules](https://nodejs.org/api/)
 
-- Publish: `npm run build Publish`
+- Tests: `npm tests` or `yarn tests`
+- Publish: `npm run build Publish` or `yarn build Publish`

--- a/src/Api.fs
+++ b/src/Api.fs
@@ -12,6 +12,11 @@ let [<Global>] require: NodeRequire = jsNative
 let [<Global>] ``module``: NodeModule = jsNative
 let [<Global>] exports: obj = jsNative
 let [<Global>] ``process``: Process.Process = jsNative
+let [<Global>] clearInterval: handle: float -> unit = jsNative
+let [<Global>] setImmediate: (unit -> unit) * [<ParamArray>] args: obj[] -> Immediate = jsNative
+let [<Global>] URL: Url.Url<string> = jsNative
+let [<Global>] URLSearchParams: Url.URLSearchParams = jsNative
+
 
 [<Import("*", "buffer")>]
 let buffer: Buffer.IExports = jsNative
@@ -49,8 +54,8 @@ let querystring: Querystring.IExports = jsNative
 [<Import("*", "stream")>]
 let stream: Stream.IExports = jsNative
 
-[<Import("*", "url")>]
-let url: Url.IExports = jsNative
+//[<Import("*", "url")>]
+//let url: Url.Url<string> = jsNative
 
 [<Import("*", "path")>]
 let path: Path.IExports = jsNative

--- a/src/Api.fs
+++ b/src/Api.fs
@@ -12,9 +12,7 @@ let [<Global>] require: NodeRequire = jsNative
 let [<Global>] ``module``: NodeModule = jsNative
 let [<Global>] exports: obj = jsNative
 let [<Global>] ``process``: Process.Process = jsNative
-let [<Global>] clearInterval: handle: float -> unit = jsNative
-let [<Global>] setImmediate: (unit -> unit) * [<ParamArray>] args: obj[] -> Immediate = jsNative
-let [<Global>] URL: Url.Url<string> = jsNative
+let [<Global>] URL: Url.URLType = jsNative
 let [<Global>] URLSearchParams: Url.URLSearchParams = jsNative
 
 
@@ -55,7 +53,7 @@ let querystring: Querystring.IExports = jsNative
 let stream: Stream.IExports = jsNative
 
 //[<Import("*", "url")>]
-//let url: Url.Url<string> = jsNative
+//let URL: Url.Url<string> = jsNative
 
 [<Import("*", "path")>]
 let path: Path.IExports = jsNative

--- a/src/Api.fs
+++ b/src/Api.fs
@@ -12,7 +12,7 @@ let [<Global>] require: NodeRequire = jsNative
 let [<Global>] ``module``: NodeModule = jsNative
 let [<Global>] exports: obj = jsNative
 let [<Global>] ``process``: Process.Process = jsNative
-//let [<Global>] URL: Url.URLType = jsNative
+let [<Global>] performance: Performance.Performance = jsNative
 let [<Global>] URLSearchParams: Url.URLSearchParams = jsNative
 
 

--- a/src/Api.fs
+++ b/src/Api.fs
@@ -12,7 +12,7 @@ let [<Global>] require: NodeRequire = jsNative
 let [<Global>] ``module``: NodeModule = jsNative
 let [<Global>] exports: obj = jsNative
 let [<Global>] ``process``: Process.Process = jsNative
-let [<Global>] URL: Url.URLType = jsNative
+//let [<Global>] URL: Url.URLType = jsNative
 let [<Global>] URLSearchParams: Url.URLSearchParams = jsNative
 
 
@@ -52,8 +52,8 @@ let querystring: Querystring.IExports = jsNative
 [<Import("*", "stream")>]
 let stream: Stream.IExports = jsNative
 
-//[<Import("*", "url")>]
-//let URL: Url.Url<string> = jsNative
+[<Import("*", "url")>]
+let URL: Url.URLType = jsNative
 
 [<Import("*", "path")>]
 let path: Path.IExports = jsNative

--- a/src/Base.fs
+++ b/src/Base.fs
@@ -21,6 +21,13 @@ type [<AllowNullLiteral>] Error =
     abstract stack: string with get, set
     abstract message: string with get, set
 
+type ItNext<'T> = 
+    abstract ``done``: bool
+    abstract value:'T
+    
+type Iterator<'T> = 
+    abstract next : unit -> ItNext<'T>
+
 type [<AllowNullLiteral>] NodeRequireFunction =
     [<Emit("$0($1...)")>] abstract Invoke: id: string -> obj
 

--- a/src/Fable.Node.fsproj
+++ b/src/Fable.Node.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Fable.Node</PackageId>
     <Version>1.0.0</Version>
-    <PackageVersion>1.0.0-beta-000</PackageVersion>
+    <PackageVersion>1.0.0-beta-001</PackageVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -24,9 +24,10 @@
     <Compile Include="ChildProcess.fs" />
     <Compile Include="OS.fs" />
     <Compile Include="Process.fs" />
+    <Compile Include="Performance.fs" />
     <Compile Include="Api.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0-beta-005" />
+    <PackageReference Include="Fable.Core" Version="3.0.0-beta-006" />
   </ItemGroup>
 </Project>

--- a/src/OS.fs
+++ b/src/OS.fs
@@ -1,7 +1,12 @@
 namespace rec Node.OS
 
 open Fable.Core
+open Fable.Core.DynamicExtensions
 open Node.Base
+
+//TODO: check constants (https://nodejs.org/docs/latest/api/os.html#os_os_constants)
+//TODO: create enum for os.types() https://nodejs.org/docs/latest/api/os.html#os_os_type
+
 
 type [<AllowNullLiteral>] CpuTimes =
     abstract user: float
@@ -35,7 +40,16 @@ type [<AllowNullLiteral>] NetworkInterfaceInfo =
     abstract scopeid: float 
     // The assigned IPv4 or IPv6 address with the routing prefix in CIDR notation. If the netmask is invalid, this property is set to null
     abstract cidr: string 
-    
+
+type NetworkInterfaceData = obj
+
+module NetworkInterfaceHelper = 
+    let getInterfaceNames (o:NetworkInterfaceData) : string seq = 
+        upcast JS.Object.keys(o)
+
+    let getInterfaceInfo (o:NetworkInterfaceData) (name:string) : NetworkInterfaceInfo seq =
+        unbox o.[name]
+
 type [<AllowNullLiteral>] Constants =
     abstract UV_UDP_REUSEADDR: float
     abstract signals: unit -> obj
@@ -76,6 +90,8 @@ type IExports =
     abstract freemem: unit -> float
     // The os.getPriority() method returns the scheduling priority for the process specified by pid. If pid is not provided, or is 0, the priority of the current process is returned.
     abstract getPriority: ?pid: int -> int
+    // The os.setPriority() method attempts to set the scheduling priority for the process specified by pid. If pid is not provided, or is 0, the priority of the current process is used.
+    abstract setPriority: ?pid: int -> int
     /// The os.homedir() method returns the home directory of the current user as a string.
     abstract homedir: unit -> string
     /// The os.hostname() method returns the hostname of the operating system as a string.
@@ -86,7 +102,7 @@ type IExports =
     abstract loadavg: unit -> (float * float * float)
     /// The os.networkInterfaces() method returns an object containing only network interfaces that have been assigned a network address.
     /// Each key on the returned object identifies a network interface. The associated value is an array of objects that each describe an assigned network address.
-    abstract networkInterfaces: unit -> obj
+    abstract networkInterfaces: unit -> NetworkInterfaceData
     /// The os.platform() method returns a string identifying the operating system platform as set during compile time of Node.js.
     abstract platform: unit -> Platform
     /// The os.release() method returns a string identifying the operating system release.
@@ -95,12 +111,12 @@ type IExports =
     /// The os.tmpdir() method returns a string specifying the operating system's default directory for temporary files.
     abstract tmpdir: unit -> string
     /// The os.totalmem() method returns the total amount of system memory in bytes as an integer.
-    abstract totalmem: unit -> float
+    abstract totalmem: unit -> int
     /// The os.type() method returns a string identifying the operating system name as returned by uname(3). For example 'Linux' on Linux, 'Darwin' on macOS and 'Windows_NT' on Windows.
     /// Please see https://en.wikipedia.org/wiki/Uname#Examples for additional information about the output of running uname(3) on various operating systems.
     abstract ``type``: unit -> string
     /// The os.uptime() method returns the system uptime in number of seconds.
     /// Note: On Windows the returned value includes fractions of a second.
-    abstract uptime: unit -> float
+    abstract uptime: unit -> int
     /// The os.userInfo() method returns information about the currently effective user -- on POSIX platforms, this is typically a subset of the password file. The returned object includes the username, uid, gid, shell, and homedir. On Windows, the uid and gid fields are -1, and shell is null.
     abstract userInfo: ?options: UserInfoOptions -> UserInfo

--- a/src/OS.fs
+++ b/src/OS.fs
@@ -4,51 +4,67 @@ open Fable.Core
 open Node.Base
 
 type [<AllowNullLiteral>] CpuTimes =
-    abstract user: float with get, set
-    abstract nice: float with get, set
-    abstract sys: float with get, set
-    abstract idle: float with get, set
-    abstract irq: float with get, set
+    abstract user: float
+    abstract nice: float
+    abstract sys: float
+    abstract idle: float
+    abstract irq: float
 
 type [<AllowNullLiteral>] CpuInfo =
-    abstract model: string with get, set
-    abstract speed: float with get, set
-    abstract times: CpuTimes with get, set
+    abstract model: string 
+    abstract speed: float
+    abstract times: CpuTimes 
+
+[<StringEnum>]
+type NetworkFamily = 
+    | IPv4 
+    | IPv6 
 
 type [<AllowNullLiteral>] NetworkInterfaceInfo =
-    abstract address: string with get, set
-    abstract netmask: string with get, set
-    abstract family: string with get, set
-    abstract mac: string with get, set
-    abstract ``internal``: bool with get, set
-
+    //The assigned IPv4 or IPv6 address
+    abstract address: string 
+    // The IPv4 or IPv6 network mask
+    abstract netmask: string
+    //Either IPv4 or IPv6 
+    abstract family: NetworkFamily 
+    // The MAC address of the network interface
+    abstract mac: string 
+    // true if the network interface is a loopback or similar interface that is not remotely accessible; otherwise false
+    abstract ``internal``: unit -> bool
+    // The numeric IPv6 scope ID (only specified when family is IPv6)
+    abstract scopeid: float 
+    // The assigned IPv4 or IPv6 address with the routing prefix in CIDR notation. If the netmask is invalid, this property is set to null
+    abstract cidr: string 
+    
 type [<AllowNullLiteral>] Constants =
-    abstract UV_UDP_REUSEADDR: float with get, set
-    abstract signals: obj with get, set
-    abstract errno: obj with get, set
+    abstract UV_UDP_REUSEADDR: float
+    abstract signals: unit -> obj
+    abstract errno: unit -> obj
+    abstract priority: unit -> obj
+    abstract dlopen: unit -> obj
 
 type [<StringEnum>] Endianness =
     | [<CompiledName("BE")>] Be | [<CompiledName("LE")>] Le
 
 type [<AllowNullLiteral>] UserInfoOptions =
-    abstract encoding: string option with get, set
+    abstract encoding: string option 
 
 type [<AllowNullLiteral>] UserInfo =
-    abstract username: string with get, set
-    abstract uid: float with get, set
-    abstract gid: float with get, set
-    abstract shell: string with get, set
-    abstract homedir: string with get, set
+    abstract username: string 
+    abstract uid: float
+    abstract gid: float
+    abstract shell: string 
+    abstract homedir: string 
 
 type IExports =
     /// A string constant defining the operating system-specific end-of-line marker:
     /// - \n on POSIX
     /// - \r\n on Windows
-    abstract EOL: string with get, set
+    abstract EOL : string
     /// The os.arch() method returns a string identifying the operating system CPU architecture for which the Node.js binary was compiled.
     abstract arch: unit -> Arch
     /// Returns an object containing commonly used operating system specific constants for error codes, process signals, and so on.
-    abstract constants: Constants with get, set
+    abstract constants: Constants 
     /// The os.cpus() method returns an array of objects containing information about each CPU/core installed.
     abstract cpus: unit -> ResizeArray<CpuInfo>
     /// The os.endianness() method returns a string identifying the endianness of the CPU for which the Node.js binary was compiled.
@@ -58,6 +74,8 @@ type IExports =
     abstract endianness: unit -> Endianness
     /// The os.freemem() method returns the amount of free system memory in bytes as an integer.
     abstract freemem: unit -> float
+    // The os.getPriority() method returns the scheduling priority for the process specified by pid. If pid is not provided, or is 0, the priority of the current process is returned.
+    abstract getPriority: ?pid: int -> int
     /// The os.homedir() method returns the home directory of the current user as a string.
     abstract homedir: unit -> string
     /// The os.hostname() method returns the hostname of the operating system as a string.

--- a/src/OS.fs
+++ b/src/OS.fs
@@ -4,7 +4,7 @@ open Fable.Core
 open Fable.Core.DynamicExtensions
 open Node.Base
 
-//TODO: check constants (https://nodejs.org/docs/latest/api/os.html#os_os_constants)
+//TODO: check constants. can't make it work. Always undefined. (https://nodejs.org/docs/latest/api/os.html#os_os_constants)
 //TODO: create enum for os.types() https://nodejs.org/docs/latest/api/os.html#os_os_type
 
 

--- a/src/Performance.fs
+++ b/src/Performance.fs
@@ -1,0 +1,18 @@
+namespace rec Node.Performance
+
+open Fable.Core
+open Node.Base
+open Fable.Core.JsInterop
+
+type [<AllowNullLiteral>] Performance =
+    abstract clearMarks: ?markName: string -> unit
+    abstract clearMeasures: ?measureName: string -> unit
+    abstract clearResourceTimings: unit -> unit
+    abstract getEntries: unit -> obj
+    abstract getEntriesByName: name: string * ?entryType: string -> obj
+    abstract getEntriesByType: entryType: string -> obj
+    abstract mark: markName: string -> unit
+    abstract ``measure``: measureName: string * ?startMarkName: string * ?endMarkName: string -> unit
+    abstract now: unit -> float
+    abstract setResourceTimingBufferSize: maxSize: float -> unit
+    abstract toJSON: unit -> obj

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -36,6 +36,8 @@ type [<AllowNullLiteral>] URLType =
     abstract Create: input:string * b: URL -> URL
     [<Emit("new $0($1...)")>] 
     abstract Create: input:string * b: string -> URL
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:string -> URL
 
 type [<AllowNullLiteral>] URL =
     abstract hash: string  with get, set
@@ -52,11 +54,11 @@ type [<AllowNullLiteral>] URL =
     abstract username: string with get, set
     abstract toString: unit -> string 
     abstract toJSON: unit -> string 
-
-module Static = 
-    let domainToASCII: string -> string = importMember "url"
-    let domainToUnicode: string -> string = importMember "url"
-    let fileURLToPath: string -> string = importMember "url"
-    let fileURLToPathFromURL: URL -> string = importMember "url"
-    let pathToFileURL: string -> URL = importMember "url"
-    //let format: string * options : IFormatOptions -> string =importMember "url"
+    
+    module Static = 
+        let domainToASCII: string -> string = importMember "url"
+        let domainToUnicode: string -> string = importMember "url"
+        let fileURLToPath: string -> string = importMember "url"
+        let fileURLToPathFromURL: URL -> string = importMember "url"
+        let pathToFileURL: string -> URL = importMember "url"
+        let format: URL * options : IFormatOptions -> string =importMember "url"

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -3,15 +3,17 @@ namespace rec Node.Url
 open Fable.Core
 open Node.Base
 
+// todo: check Static.format can't make it work. See commented sample in tests
+
 type IFormatOptions = 
-    abstract auth:string option 
-    abstract fragment:bool option
-    abstract search:bool option
-    abstract unicode:bool option
+    abstract auth:bool option with get, set
+    abstract fragment:bool option with get, set
+    abstract search:bool option with get, set
+    abstract unicode:bool option with get, set
 
 type [<AllowNullLiteral>] URLSearchParams = 
     [<Emit("new $0($1...)")>] 
-    abstract Create: input:U4<unit, string,obj, obj> -> URLSearchParams
+    abstract Create: input:U3<unit, string,URLSearchParams> -> URLSearchParams
     abstract append: string * string -> unit
     abstract delete: string -> unit
     abstract get: string -> string option
@@ -21,13 +23,14 @@ type [<AllowNullLiteral>] URLSearchParams =
     abstract set: name:string * value:string -> unit
     abstract sort: unit -> unit
     abstract toString: unit -> string 
-    abstract values: unit -> Iterator<string*string []>
-    abstract entries: unit -> Iterator<string*string []>
-    //abstract forEach: string * string -> obj
+    abstract values: unit -> string [] 
+    abstract entries: unit -> (string*string) []
 
-type [<AllowNullLiteral>] Url<'a> =
+type [<AllowNullLiteral>] URLType =
     [<Emit("new $0($1...)")>] 
-    abstract Create: input:string * b: U2<Url<string>, string> -> Url<string>
+    abstract Create: input:string * b: U2<URL, string> -> URL
+
+type [<AllowNullLiteral>] URL =
     abstract hash: string  with get, set
     abstract host: string  with get, set
     abstract hostname: string  with get, set
@@ -43,9 +46,10 @@ type [<AllowNullLiteral>] Url<'a> =
     abstract toString: unit -> string 
     abstract toJSON: unit -> string 
 
-//type IExports =
-    abstract domainToASCII: string -> string
-    abstract domainToUnicode: string -> string
-    abstract fileURLToPath: U2<Url<string>,string> -> string
-    abstract pathToFileURL: string -> Url<string>
-    abstract format: url: Url<string> * ?options: IFormatOptions -> string
+[<Import("*", "url")>]
+type Static = 
+    static member domainToASCII: string -> string = jsNative
+    static member domainToUnicode: string -> string = jsNative
+    static member fileURLToPath: U2<URL,string> -> string = jsNative
+    static member pathToFileURL: string -> URL = jsNative
+    static member format: URL * options : IFormatOptions -> string = jsNative

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -6,6 +6,12 @@ open Fable.Core.JsInterop
 
 // todo: check Static.format can't make it work. See commented sample in tests
 
+type LegacyFormatOptions =
+    abstract member protocol : string with get, set
+    abstract member hostname : string with get, set
+    abstract member pathname : string with get, set
+    abstract member query : obj with get, set
+    
 type IFormatOptions = 
     abstract auth:bool option with get, set
     abstract fragment:bool option with get, set
@@ -32,12 +38,14 @@ type [<AllowNullLiteral>] URLSearchParams =
     abstract entries: unit -> (string*string) []
 
 type [<AllowNullLiteral>] URLType =
-    [<Emit("new $0($1...)")>] 
+    [<Emit("new URL($1...)")>] 
     abstract Create: input:string * b: URL -> URL
-    [<Emit("new $0($1...)")>] 
+    [<Emit("new URL($1...)")>] 
     abstract Create: input:string * b: string -> URL
-    [<Emit("new $0($1...)")>] 
+    [<Emit("new URL($1...)")>]
     abstract Create: input:string -> URL
+    abstract format: URL * options : IFormatOptions -> string 
+    abstract format: options : LegacyFormatOptions -> string 
 
 type [<AllowNullLiteral>] URL =
     abstract hash: string  with get, set
@@ -54,11 +62,10 @@ type [<AllowNullLiteral>] URL =
     abstract username: string with get, set
     abstract toString: unit -> string 
     abstract toJSON: unit -> string 
-    
-    module Static = 
-        let domainToASCII: string -> string = importMember "url"
-        let domainToUnicode: string -> string = importMember "url"
-        let fileURLToPath: string -> string = importMember "url"
-        let fileURLToPathFromURL: URL -> string = importMember "url"
-        let pathToFileURL: string -> URL = importMember "url"
-        let format: URL * options : IFormatOptions -> string =importMember "url"
+
+module Static = 
+    let domainToASCII: string -> string = importMember  "url"
+    let domainToUnicode: string -> string = importMember  "url"
+    let fileURLToPath: string -> string = importMember  "url"
+    let fileURLToPathFromURL: URL -> string = importMember  "url"
+    let pathToFileURL: string -> URL = importMember  "url"

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -2,6 +2,7 @@ namespace rec Node.Url
 
 open Fable.Core
 open Node.Base
+open Fable.Core.JsInterop
 
 // todo: check Static.format can't make it work. See commented sample in tests
 
@@ -52,10 +53,10 @@ type [<AllowNullLiteral>] URL =
     abstract toString: unit -> string 
     abstract toJSON: unit -> string 
 
-[<Import("*", "url")>]
-type Static = 
-    static member domainToASCII: string -> string = jsNative
-    static member domainToUnicode: string -> string = jsNative
-    static member fileURLToPath: U2<URL,string> -> string = jsNative
-    static member pathToFileURL: string -> URL = jsNative
-    static member format: URL * options : IFormatOptions -> string = jsNative
+module Static = 
+    let domainToASCII: string -> string = importMember "url"
+    let domainToUnicode: string -> string = importMember "url"
+    let fileURLToPath: string -> string = importMember "url"
+    let fileURLToPathFromURL: URL -> string = importMember "url"
+    let pathToFileURL: string -> URL = importMember "url"
+    //let format: string * options : IFormatOptions -> string =importMember "url"

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -1,25 +1,51 @@
 namespace rec Node.Url
 
 open Fable.Core
+open Node.Base
+
+type IFormatOptions = 
+    abstract auth:string option 
+    abstract fragment:bool option
+    abstract search:bool option
+    abstract unicode:bool option
+
+type [<AllowNullLiteral>] URLSearchParams = 
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:U4<unit, string,obj, obj> -> URLSearchParams
+    abstract append: string * string -> unit
+    abstract delete: string -> unit
+    abstract get: string -> string option
+    abstract getAll: string -> string []
+    abstract has: string -> bool
+    abstract keys: unit -> string []
+    abstract set: name:string * value:string -> unit
+    abstract sort: unit -> unit
+    abstract toString: unit -> string 
+    abstract values: unit -> Iterator<string*string []>
+    abstract entries: unit -> Iterator<string*string []>
+    //abstract forEach: string * string -> obj
 
 type [<AllowNullLiteral>] Url<'a> =
-    abstract href: string option with get, set
-    abstract protocol: string option with get, set
-    abstract auth: string option with get, set
-    abstract hostname: string option with get, set
-    abstract port: string option with get, set
-    abstract host: string option with get, set
-    abstract pathname: string option with get, set
-    abstract search: string option with get, set
-    abstract query: 'a option with get, set
-    abstract slashes: bool option with get, set
-    abstract hash: string option with get, set
-    abstract path: string option with get, set
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:string * b: U2<Url<string>, string> -> Url<string>
+    abstract hash: string  with get, set
+    abstract host: string  with get, set
+    abstract hostname: string  with get, set
+    abstract href: string  with get, set
+    abstract origin: string  
+    abstract password: string  with get, set
+    abstract pathname: string  with get, set
+    abstract port: string  with get, set
+    abstract protocol: string with get, set
+    abstract search: string with get, set
+    abstract searchParams: URLSearchParams
+    abstract username: string with get, set
+    abstract toString: unit -> string 
+    abstract toJSON: unit -> string 
 
-type IExports =
-    abstract parse: urlStr: string -> Url<string>
-    abstract parse: urlStr: string * ?parseQueryString: bool -> Url<obj>
-    abstract parse: urlStr: string * ?parseQueryString: bool * ?slashesDenoteHost: bool -> Url<U2<string, obj>>
-    abstract format: url: Url<string> -> string
-    abstract format: url: Url<obj> -> string
-    abstract resolve: from: string * ``to``: string -> string
+//type IExports =
+    abstract domainToASCII: string -> string
+    abstract domainToUnicode: string -> string
+    abstract fileURLToPath: U2<Url<string>,string> -> string
+    abstract pathToFileURL: string -> Url<string>
+    abstract format: url: Url<string> * ?options: IFormatOptions -> string

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -13,7 +13,11 @@ type IFormatOptions =
 
 type [<AllowNullLiteral>] URLSearchParams = 
     [<Emit("new $0($1...)")>] 
-    abstract Create: input:U3<unit, string,URLSearchParams> -> URLSearchParams
+    abstract Create: input:string -> URLSearchParams
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:unit -> URLSearchParams
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:URLSearchParams -> URLSearchParams
     abstract append: string * string -> unit
     abstract delete: string -> unit
     abstract get: string -> string option
@@ -28,7 +32,9 @@ type [<AllowNullLiteral>] URLSearchParams =
 
 type [<AllowNullLiteral>] URLType =
     [<Emit("new $0($1...)")>] 
-    abstract Create: input:string * b: U2<URL, string> -> URL
+    abstract Create: input:string * b: URL -> URL
+    [<Emit("new $0($1...)")>] 
+    abstract Create: input:string * b: string -> URL
 
 type [<AllowNullLiteral>] URL =
     abstract hash: string  with get, set

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -1,0 +1,20 @@
+module Tests.Main
+
+open Fable.Core
+
+let [<Global>] describe (name: string) (f: unit->unit) = jsNative
+let [<Global>] it (msg: string) (f: unit->unit) = jsNative
+
+let run () =
+    let tests = [ OS.tests
+                  Path.tests
+                ] :> Util.Test seq
+
+    for (moduleName, moduleTests) in tests do
+        describe moduleName <| fun () ->
+            for (name, tests) in moduleTests do
+                describe name <| fun _ ->
+                    for (msg, test) in tests do
+                        it msg test
+
+run()

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -6,8 +6,10 @@ let [<Global>] describe (name: string) (f: unit->unit) = jsNative
 let [<Global>] it (msg: string) (f: unit->unit) = jsNative
 
 let run () =
-    let tests = [ OS.tests
-                  Path.tests
+    let tests = [ 
+                    Url.tests
+                    OS.tests
+                    Path.tests
                 ] :> Util.Test seq
 
     for (moduleName, moduleTests) in tests do

--- a/tests/OS.fs
+++ b/tests/OS.fs
@@ -1,0 +1,102 @@
+module Tests.OS
+
+open System
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.DynamicExtensions
+open Node.OS
+open Util
+
+let Os = Node.Api.os
+
+let tests : Test = 
+  testList "OS" [
+  
+    testList "os.EOL" [
+      testCase "Windows" <| fun _ ->
+        if isPosix then testPassed()
+        else
+          Os.EOL |> equal "\r\n"
+
+      testCase "POSIX" <| fun _ ->
+        if not isPosix then testPassed()
+        else
+          Os.EOL |> equal "\n"
+    ]
+    
+    testList "os.arch" [
+      testCase "arch" <| fun _ ->
+        printfn "%s" (string (Os.arch()))
+        (string (Os.arch())).Length > 0 |> equal true
+    ]
+
+    (*
+    testList "os.constants" [
+      testCase "os.constants" <| fun _ ->
+        printfn "%s" (Os?constants )
+        testPassed // need to determine how it works
+    ]
+    *)
+
+    testList "os.cpus" [
+      testCase "cpus" <| fun _ ->
+        let ok = 
+          let cpuList = Os.cpus()
+          let first = cpuList |> Seq.head
+          printfn "%s" (first.model)
+          first.model.Length > 0
+          && first.speed > 0.
+          && first.times.user >= 0.
+          && first.times.nice >= 0.
+          && first.times.sys >= 0.
+          && first.times.idle >= 0.
+          && first.times.irq >= 0.
+
+        ok |> equal true
+    ]
+
+    testList "os.endianness" [
+      testCase "endianness" <| fun _ ->
+        printfn "%s" (string (Os.endianness()))
+        (string (Os.endianness())).Length > 0 |> equal true
+    ]
+
+    testList "os.freemem" [
+      testCase "freemem" <| fun _ ->
+        printfn "%f" (Os.freemem())
+        Os.freemem() > 0. |> equal true // hopefully ;)
+    ]
+
+    testList "os.getPriority" [
+      testCase "getPriority" <| fun _ ->
+        printfn "p=%i" (Os.getPriority 0)
+        testPassed()
+    ]
+
+    testList "os.homedir" [
+      testCase "homedir" <| fun _ ->
+        printfn "%s" (Os.homedir())
+        Os.homedir().Length >0  |> equal true
+    ]
+
+    testList "os.hostname" [
+      testCase "hostname" <| fun _ ->
+        printfn "%s" (Os.hostname())
+        Os.hostname().Length >0  |> equal true
+    ]
+
+    testList "os.loadavg" [
+      testCase "loadavg" <| fun _ ->
+        printfn "%A" (Os.loadavg())
+        let m1, m5, m15 = Os.loadavg()
+        let ok = m1 >= 0. && m5 >= 0. && m15 >=0.
+        ok |> equal true
+    ]
+
+    testList "os.networkInterfaces" [
+      testCase "networkInterfaces" <| fun _ ->
+        printfn "%O" (Os.networkInterfaces())
+        testPassed()
+    ]    
+
+  ]

--- a/tests/OS.fs
+++ b/tests/OS.fs
@@ -33,8 +33,8 @@ let tests : Test =
     (*
     testList "os.constants" [
       testCase "os.constants" <| fun _ ->
-        printfn "%s" (Os?constants )
-        testPassed // need to determine how it works
+        printfn "%O" (Os?Constants )
+        testPassed() // need to determine how it works
     ]
     *)
 

--- a/tests/OS.fs
+++ b/tests/OS.fs
@@ -95,8 +95,62 @@ let tests : Test =
 
     testList "os.networkInterfaces" [
       testCase "networkInterfaces" <| fun _ ->
-        printfn "%O" (Os.networkInterfaces())
+        let data = Os.networkInterfaces()
+        let keys = data |> Node.OS.NetworkInterfaceHelper.getInterfaceNames
+        keys 
+          |> Seq.iter( fun key -> 
+            let infos = Node.OS.NetworkInterfaceHelper.getInterfaceInfo data key
+            infos |> Seq.iter( fun info -> printfn "%s:%s" key info.address )            
+          ) 
         testPassed()
     ]    
 
+    testList "os.platform" [
+      testCase "platform" <| fun _ ->
+        let v = string (Os.platform())
+        printfn "%s" v
+        v.Length > 0  |> equal true
+    ]
+
+    testList "os.release" [
+      testCase "release" <| fun _ ->
+        let v = string (Os.release())
+        printfn "%s" v
+        v.Length > 0  |> equal true
+    ]
+
+    testList "os.tmpdir" [
+      testCase "tmpdir" <| fun _ ->
+        let v = string (Os.tmpdir())
+        printfn "%s" v
+        v.Length > 0  |> equal true
+    ]    
+
+    testList "os.totalmem" [
+      testCase "totalmem" <| fun _ ->
+        let v = string (Os.totalmem())
+        printfn "%s" v
+        Os.totalmem() <> 0  |> equal true
+    ]        
+
+    testList "os.type" [
+      testCase "type" <| fun _ ->
+        let v = string (Os.``type``())
+        printfn "%s" v
+        v.Length > 0  |> equal true
+    ]    
+
+    testList "os.uptime" [
+      testCase "uptime" <| fun _ ->
+        let v = string (Os.uptime())
+        printfn "%s" v
+        Os.uptime() <> 0  |> equal true
+    ]
+
+    testList "os.userInfo" [
+      testCase "userInfo" <| fun _ ->
+        let info = Os.userInfo()
+        printfn "%s" info.homedir
+        testPassed()
+    ]    
   ]

--- a/tests/Path.fs
+++ b/tests/Path.fs
@@ -4,175 +4,157 @@ open System
 open Fable.Core
 open Fable.Core.JsInterop
 open Node.Path
+open Util
 
-let inline equal (expected: 'T) (actual: 'T): unit =
-    Testing.Assert.AreEqual(expected, actual)
+let path = Node.Api.path
+let testAbsolute p result = path.isAbsolute p |> equal result
 
-[<Global>]
-let it (msg: string) (f: unit->unit): unit = jsNative
-
-[<Global("it")>]
-let itSync (msg: string) (f: unit->unit): unit = jsNative
-
-[<Global>]
-let describe (msg: string) (f: unit->unit): unit = jsNative
-
-type DisposableAction(f) =
-    interface IDisposable with
-        member __.Dispose() = f()
-
-describe "tests" <| fun _ ->
+let tests : Test = 
+  testList "Path" [
   
-  describe "path.basename" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "Windows" <| fun () ->
+    testList "path.basename" [
+      testCase "Windows" <| fun _ ->
+        if isPosix then testPassed()
+        else
           path.basename "c:\\windows\\command.com"
             |> equal "command.com"
 
-      it "win32" <| fun () ->
+      testCase "win32" <| fun _ ->
+        if isPosix then testPassed()
+        else
           path.win32.basename "c:\\windows\\command.com"
             |> equal "command.com"        
-    | _ -> //posix
-      it "POSIX" <| fun () ->
+
+      testCase "POSIX" <| fun _ ->
+        if not isPosix then testPassed()
+        else
           path.basename "c:\\windows\\command.com" 
             |> equal "c:\\windows\\command.com"
 
-      it "posix" <| fun () ->
+      testCase "POSIX" <| fun _ ->
+        if not isPosix then testPassed()
+        else
           path.posix.basename "/tmp/index.html"
             |> equal "index.htdml"                
+    ]
 
-  describe "path.delimiter" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "Windows" <| fun () -> path.delimiter |> equal ";"
-    | _ -> //posix
-      it "POSIX" <| fun () -> path.delimiter |> equal ":"
+    testList "path.delimiter" [
+      testCase "Windows" <| fun _ -> 
+        if isPosix then testPassed()
+        else
+          path.delimiter |> equal ";"
 
-  describe "path.dirname" <| fun _ ->
-    let path = Node.Api.path
-    it "returns directory name" <| fun () -> path.dirname "/foo/bar/baz/asdf/quux" |> equal "/foo/bar/baz/asdf"
+      testCase "POSIX" <| fun _ -> 
+        if not isPosix then testPassed()
+        else
+          path.delimiter |> equal ":"
+    ]
 
-  describe "path.extname" <| fun _ ->
-    let path = Node.Api.path
-    it "returns the extension of the path" <| fun () -> path.extname "index.html" |> equal ".html"
-    it "returns the extension of the path" <| fun () -> path.extname "index.coffee.md" |> equal ".md"
-    it "returns the extension of the path" <| fun () -> path.extname "index." |> equal "."
-    it "returns the extension of the path" <| fun () -> path.extname "index" |> equal ""
-    it "returns the extension of the path" <| fun () -> path.extname ".index" |> equal ""
+    testList "path.dirname" [
+      testCase "returns directory name" <| fun _ -> path.dirname "/foo/bar/baz/asdf/quux" |> equal "/foo/bar/baz/asdf"
+    ]
 
-  describe "path.format" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "Windows" <| fun () -> 
-        let options = jsOptions<Node.Path.PathObjectProps>(fun o -> 
-          o.dir <- "C:\\path\\dir"
-          o.baseName <- "file.txt" // `base` in javascript
-        )
-        path.format options |> equal "C:\\path\\dir\\file.txt"
+    testList "path.extname" [ 
+      testCase "returns the extension of the path" <| fun _ -> path.extname "index.html" |> equal ".html"
+      testCase "returns the extension of the path" <| fun _ -> path.extname "index.coffee.md" |> equal ".md"
+      testCase "returns the extension of the path" <| fun _ -> path.extname "index." |> equal "."
+      testCase "returns the extension of the path" <| fun _ -> path.extname "index" |> equal ""
+      testCase "returns the extension of the path" <| fun _ -> path.extname ".index" |> equal ""
+    ]
 
-    | _ -> //posix
-      it "POSIX" <| fun () -> 
-        let options = jsOptions<Node.Path.PathObjectProps>(fun o -> 
-          o.root <- "ignored"
-          o.dir <- "/home/user/dir"
-          o.baseName <- "file.txt" // `base` in javascript
-        )
-        path.format options |> equal "/home/user/dir/file.txt"
-
-  describe "path.absolute" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    let test p result = path.isAbsolute p |> equal result
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      
-      it "Windows" <| fun () -> test "//server" true
-      it "Windows" <| fun () -> test "\\\\server" true
-      it "Windows" <| fun () -> test "C:/foo/.." true
-      it "Windows" <| fun () -> test "C:\\foo\\.." true
-      it "Windows" <| fun () -> test "bar\\baz" false
-      it "Windows" <| fun () -> test "bar/baz" false
-      it "Windows" <| fun () -> test "." false
-
-    | _ -> //posix
-      it "POSIX" <| fun () -> test "/foo/bar" true
-      it "POSIX" <| fun () -> test "/baz/.." true
-      it "POSIX" <| fun () -> test "qux/.." false
-      it "POSIX" <| fun () -> test "." false
-
-  describe "path.join" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "windows" <| fun () -> path.join [|"/foo";"bar";"baz/asdf";"quux";".."|] |> equal "\\foo\\bar\\baz\\asdf"
-    | _ -> //posix
-      it "posix" <| fun () -> path.join [|"/foo";"bar";"baz/asdf";"quux";".."|] |> equal "/foo/bar/baz/asdf"
-
-  describe "path.normalize" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "windows" <| fun () -> path.normalize "C:\\temp\\\\foo\\bar\\..\\" |> equal "C:\\temp\\foo\\"
-      it "windows" <| fun () -> path.win32.normalize "C:////temp\\\\/\\/\\/foo/bar" |> equal "C:\\temp\\foo\\bar"
-    | _ -> //posix
-      it "posix" <| fun () -> path.normalize "/foo/bar//baz/asdf/quux/.." |> equal "/foo/bar/baz/asdf"
-
-  describe "path.parse" <| fun _ ->
-    let toString (parsed:PathObjectProps) = 
-      sprintf "%s %s %s %s %s " parsed.root parsed.dir parsed.baseName parsed.ext parsed.name
-
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "windows" <| fun () -> 
-        let pathObject = 
-          jsOptions<PathObjectProps>(fun o -> 
-            o.root <- "C:\\"
+    testList "path.format" [
+      testCase "Windows" <| fun _ -> 
+        if isPosix then testPassed()
+        else
+          let options = jsOptions<Node.Path.PathObjectProps>(fun o -> 
             o.dir <- "C:\\path\\dir"
-            o.baseName <- "file.txt"
-            o.ext <- ".txt"
-            o.name <- "file")
+            o.baseName <- "file.txt" // `base` in javascript
+          )
+          path.format options |> equal "C:\\path\\dir\\file.txt"
 
-        let parsed = path.parse "C:\\path\\dir\\file.txt" 
-        (parsed |> toString) = (pathObject |> toString) |> equal true 
-    | _ -> //posix
-      it "posix" <| fun () -> 
-        let pathObject = 
-          jsOptions<PathObjectProps>(fun o -> 
-            o.root <- "/"
+      testCase "POSIX" <| fun _ -> 
+        if not isPosix then testPassed()
+        else
+          let options = jsOptions<Node.Path.PathObjectProps>(fun o -> 
+            o.root <- "ignored"
             o.dir <- "/home/user/dir"
-            o.baseName <- "file.txt"
-            o.ext <- ".txt"
-            o.name <- "file")
-            
-        let parsed = path.parse "/home/user/dir/file.txt"
-        (parsed |> toString) = (pathObject |> toString) |> equal true 
+            o.baseName <- "file.txt" // `base` in javascript
+          )
+          path.format options |> equal "/home/user/dir/file.txt"
+    ]        
 
-  describe "path.relative" <| fun _ ->
-    let path = Node.Api.path
-    let p = Node.Api.``process``.platform
-    match p with 
-    | Node.Base.Platform.Win32 -> 
-      it "windows" <| fun () -> path.relative("C:\\orandea\\test\\aaa", "C:\\orandea\\impl\\bbb") |> equal "..\\..\\impl\\bbb"
-    | _ -> //posix
-      it "posix" <| fun () -> path.relative("/data/orandea/test/aaa", "/data/orandea/impl/bbb") |> equal "../../impl/bbb"
+    testList "path.absolute" [        
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "//server" true
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "\\\\server" true
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "C:/foo/.." true
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "C:\\foo\\.." true
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "bar\\baz" false
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "bar/baz" false
+      testCase "Windows" <| fun _ -> if isPosix then testPassed() else testAbsolute "." false
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else testAbsolute "/foo/bar" true
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else testAbsolute "/baz/.." true
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else testAbsolute "qux/.." false
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else testAbsolute "." false
+    ]
+    
+    testList "path.join" [
+      testCase "windows" <| fun _ -> if isPosix then testPassed() else path.join [|"/foo";"bar";"baz/asdf";"quux";".."|] |> equal "\\foo\\bar\\baz\\asdf"
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else path.join [|"/foo";"bar";"baz/asdf";"quux";".."|] |> equal "/foo/bar/baz/asdf"
+    ]
 
-  describe "path.resolve & path.sep" <| fun _ ->
-    let path = Node.Api.path
-    let separatorChar = System.Convert.ToChar path.sep 
-    it "all platforms" <| fun () ->
-      let wanted = [|"foo";"bar";"baz"|] 
-      path.resolve("/foo/bar", "baz")
-        .Split(separatorChar) 
-        |> Array.filter (fun x ->  wanted |> Array.contains x)
-        |> equal wanted
+    testList "path.normalize" [
+      testCase "windows" <| fun _ -> if isPosix then testPassed() else path.normalize "C:\\temp\\\\foo\\bar\\..\\" |> equal "C:\\temp\\foo\\"
+      testCase "windows" <| fun _ -> if isPosix then testPassed() else path.win32.normalize "C:////temp\\\\/\\/\\/foo/bar" |> equal "C:\\temp\\foo\\bar"
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else path.normalize "/foo/bar//baz/asdf/quux/.." |> equal "/foo/bar/baz/asdf"
+    ]
+
+    testList "path.parse" [
+      testCase "windows" <| fun _ -> 
+        if isPosix then testPassed() 
+        else
+          let toString (parsed:PathObjectProps) = 
+            sprintf "%s %s %s %s %s " parsed.root parsed.dir parsed.baseName parsed.ext parsed.name
+          let pathObject = 
+            jsOptions<PathObjectProps>(fun o -> 
+              o.root <- "C:\\"
+              o.dir <- "C:\\path\\dir"
+              o.baseName <- "file.txt"
+              o.ext <- ".txt"
+              o.name <- "file")
+
+          let parsed = path.parse "C:\\path\\dir\\file.txt" 
+          (parsed |> toString) = (pathObject |> toString) |> equal true 
+
+
+      testCase "POSIX" <| fun _ -> 
+        if not isPosix then testPassed() 
+        else
+          let toString (parsed:PathObjectProps) = 
+            sprintf "%s %s %s %s %s " parsed.root parsed.dir parsed.baseName parsed.ext parsed.name
+          let pathObject = 
+            jsOptions<PathObjectProps>(fun o -> 
+              o.root <- "/"
+              o.dir <- "/home/user/dir"
+              o.baseName <- "file.txt"
+              o.ext <- ".txt"
+              o.name <- "file")
+              
+          let parsed = path.parse "/home/user/dir/file.txt"
+          (parsed |> toString) = (pathObject |> toString) |> equal true 
+    ]
+
+    testList "path.relative" [
+      testCase "windows" <| fun _ -> if isPosix then testPassed() else path.relative("C:\\orandea\\test\\aaa", "C:\\orandea\\impl\\bbb") |> equal "..\\..\\impl\\bbb"
+      testCase "POSIX" <| fun _ -> if not isPosix then testPassed() else path.relative("/data/orandea/test/aaa", "/data/orandea/impl/bbb") |> equal "../../impl/bbb"
+    ]
+
+    testList "path.resolve & path.sep" [
+      testCase "all platforms" <| fun _ ->
+        let separatorChar = System.Convert.ToChar path.sep 
+        let wanted = [|"foo";"bar";"baz"|] 
+        path.resolve("/foo/bar", "baz")
+          .Split(separatorChar) 
+          |> Array.filter (fun x ->  wanted |> Array.contains x)
+          |> equal wanted
+    ]
+  ]

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="Util.fs" />
     <Compile Include="Path.fs" />
     <Compile Include="OS.fs" />
+    <Compile Include="Url.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -10,9 +10,6 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0-beta-005" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\src\Node.fsproj" />
+    <ProjectReference Include="..\src\Fable.Node.fsproj" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -3,7 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Util.fs" />
     <Compile Include="Path.fs" />
+    <Compile Include="OS.fs" />
+    <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.0.0-beta-005" />

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -168,13 +168,14 @@ let tests : Test =
       
       testCase "fileURLToPath" <| fun _ ->
           if isPosix then 
-            Node.Url.Static.fileURLToPath !^"file:///你好.txt" = "/你好.txt " |> equal true
+            Node.Url.Static.fileURLToPath "file:///你好.txt" = "/你好.txt " |> equal true
           else
-            Node.Url.Static.fileURLToPath !^"file:///C:/path/" = """C:/path/""" |> equal true
+            Node.Url.Static.fileURLToPath "file:///C:/path/" = """C:/path/""" |> equal true
 
+      
       (*
       testCase "format" <| fun _ ->
-          let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
+//          let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
           let formatOptions = jsOptions<Node.Url.IFormatOptions>( fun o -> 
             o.fragment <- Some false
             o.unicode <- Some true
@@ -187,8 +188,8 @@ let tests : Test =
               "unicode" ==> true
               "auth" ==> false
             ]
-          printfn "format: %s" (Node.Url.Static.format(url,formatOptions))
-          Node.Url.Static.format(url,!!test) = "https://測試/?abc" |> equal true
+          printfn "format: %s" (Node.Url.Static.format("https://a:b@測試?abc#foo",formatOptions))
+          Node.Url.Static.format("https://a:b@測試?abc#foo",!!test) = "https://測試/?abc" |> equal true
 //          Node.Url.Static.format(url,formatOptions) = "https://測試/?abc" |> equal true
         *)
     ]

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -9,7 +9,7 @@ open Util
 
 let URL = Node.Api.URL
 
-let makeUrl input (b:string) :Node.Url.Url<string> = URL.Create(input, !^b)
+let makeUrl input (b:string) :Node.Url.URL = URL.Create(input, !^b)
 
 let tests : Test = 
   testList "Url" [
@@ -20,132 +20,132 @@ let tests : Test =
           url.href = "https://example.org/foo" |> equal true
 
       testCase "unicode" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://測試")
+          let url : Node.Url.URL = URL.Create("https://測試")
           (url.href = "https://xn--g6w251d/" // with node compiled with ICU enabled
             || url.href = "https://測試") |> equal true
     ]
 
     testList "hash" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo#bar")
+          let url : Node.Url.URL = URL.Create("https://example.org/foo#bar")
           url.hash = "#bar" |> equal true
       
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo#bar")
+          let url : Node.Url.URL = URL.Create("https://example.org/foo#bar")
           url.hash <- "baz"
           url.href = "https://example.org/foo#baz" |> equal true
     ]
 
     testList "host" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.host = "example.org:81" |> equal true
       
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.host <- "example.com:82"
           url.href = "https://example.com:82/foo" |> equal true
     ]
 
     testList "hostname" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.hostname = "example.org" |> equal true
       
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.hostname <- "example.com:82"
           url.href = "https://example.com:81/foo" |> equal true
     ]
 
     testList "href" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo")
+          let url : Node.Url.URL = URL.Create("https://example.org/foo")
           url.href = "https://example.org/foo" |> equal true
       
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/bar")
+          let url : Node.Url.URL = URL.Create("https://example.org/bar")
           url.href <- "https://example.org/foo"
           url.href = "https://example.org/foo" |> equal true
     ]
 
     testList "origin" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo/bar?baz")
+          let url : Node.Url.URL = URL.Create("https://example.org/foo/bar?baz")
           url.origin = "https://example.org" |> equal true
       
       testCase "unicode" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://測試")
+          let url : Node.Url.URL = URL.Create("https://測試")
           url.origin = "https://xn--g6w251d" |> equal true
     ]
 
     testList "password" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          let url : Node.Url.URL = URL.Create("https://abc:xyz@example.com")
           url.password = "xyz" |> equal true
 
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          let url : Node.Url.URL = URL.Create("https://abc:xyz@example.com")
           url.password <- "123" 
           url.href = "https://abc:123@example.com/" |> equal true  
     ]
 
     testList "pathname" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc/xyz?123")
+          let url : Node.Url.URL = URL.Create("https://example.org/abc/xyz?123")
           url.pathname = "/abc/xyz" |> equal true
 
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc/xyz?123")
+          let url : Node.Url.URL = URL.Create("https://example.org/abc/xyz?123")
           url.pathname <- "/abcdef" 
           url.href = "https://example.org/abcdef?123" |> equal true  
     ]
 
     testList "port" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          let url : Node.Url.URL = URL.Create("https://example.org:8888")
           url.port = "8888" |> equal true
 
       testCase "443" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          let url : Node.Url.URL = URL.Create("https://example.org:8888")
           url.port <- "443"
           (url.port = "" && url.href = "https://example.org/") |> equal true  
 
       testCase "1234" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          let url : Node.Url.URL = URL.Create("https://example.org:8888")
           url.port <- "1234"
           (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
 
       testCase "abcd" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          let url : Node.Url.URL = URL.Create("https://example.org:8888")
           url.port <- "1234"
           url.port <- "abcd"
           (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
 
       testCase "abcd" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          let url : Node.Url.URL = URL.Create("https://example.org:8888")
           url.port <- "1234.5678"
           (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
     ]
 
     testList "protocol" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org")
+          let url : Node.Url.URL = URL.Create("https://example.org")
           url.protocol = "https:" |> equal true
 
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org")
+          let url : Node.Url.URL = URL.Create("https://example.org")
           url.protocol <- "ftp"
           url.href = "ftp://example.org/" |> equal true  
     ]
 
     testList "search" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc?123")
+          let url : Node.Url.URL = URL.Create("https://example.org/abc?123")
           url.search = "?123" |> equal true
 
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc?123")
+          let url : Node.Url.URL = URL.Create("https://example.org/abc?123")
           url.search = "?123" |> equal true
           url.search <- "abc=xyz"
           url.href = "https://example.org/abc?abc=xyz" |> equal true  
@@ -153,13 +153,101 @@ let tests : Test =
 
     testList "username" [
       testCase "get" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          let url : Node.Url.URL = URL.Create("https://abc:xyz@example.com")
           url.username = "abc" |> equal true
 
       testCase "set" <| fun _ ->
-          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          let url : Node.Url.URL = URL.Create("https://abc:xyz@example.com")
           url.username <- "123" 
           url.href = "https://123:xyz@example.com/" |> equal true  
+    ]
+
+    testList "static" [
+      testCase "domainToUnicode" <| fun _ ->
+          Node.Url.Static.domainToUnicode "xn--espaol-zwa.com" = "español.com" |> equal true
+      
+      testCase "fileURLToPath" <| fun _ ->
+          if isPosix then 
+            Node.Url.Static.fileURLToPath !^"file:///你好.txt" = "/你好.txt " |> equal true
+          else
+            Node.Url.Static.fileURLToPath !^"file:///C:/path/" = """C:/path/""" |> equal true
+
+      (*
+      testCase "format" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
+          let formatOptions = jsOptions<Node.Url.IFormatOptions>( fun o -> 
+            o.fragment <- Some false
+            o.unicode <- Some true
+            o.auth <- Some false
+            o.search <- Some true
+          )
+          let test = 
+            createObj [
+              "fragment" ==> false
+              "unicode" ==> true
+              "auth" ==> false
+            ]
+          printfn "format: %s" (Node.Url.Static.format(url,formatOptions))
+          Node.Url.Static.format(url,!!test) = "https://測試/?abc" |> equal true
+//          Node.Url.Static.format(url,formatOptions) = "https://測試/?abc" |> equal true
+        *)
+    ]
+
+    testList "URLSearchParams" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.get "abc" = Some "123" |> equal true  
+
+      testCase "get" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.get "123" = None |> equal true  
+
+      testCase "getAll" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.getAll "abc" |> Seq.head = "123" |> equal true  
+
+      testCase "has" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.has "def" |> equal false
+
+      testCase "keys" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?foo=bar&foo=baz")
+          url.searchParams.keys() |> String.concat "/" = "foo/foo" |> equal true
+
+      testCase "values" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?foo=bar&foo=baz")
+          url.searchParams.values() |> String.concat "/" = "bar/baz" |> equal true
+
+      testCase "entries" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?foo=bar&foo=baz")
+          url.searchParams.entries() 
+            |> Seq.map( fun (k,v) -> k+v) 
+            |> String.concat "/" = "foobar/foobaz" 
+            |> equal true
+
+      testCase "sort" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?query[]=abc&type=search&query[]=123")
+          url.searchParams.sort() 
+          url.searchParams.toString() = "query%5B%5D=abc&query%5B%5D=123&type=search" |> equal true
+
+      testCase "append" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.append("abc","xyz")
+          url.href = "https://example.org/?abc=123&abc=xyz" |> equal true  
+
+      testCase "delete" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?abc=123")
+          url.searchParams.delete "abc"
+          url.searchParams.set("a","b")
+          url.href = "https://example.org/?a=b" |> equal true  
+
+      testCase "new" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org/?a=b")          
+          let newSearchParams  : Node.Url.URLSearchParams = Node.Api.URLSearchParams.Create(!^url.searchParams)
+          newSearchParams.append("a","c")
+          (url.href = "https://example.org/?a=b" 
+            && newSearchParams.toString() = "a=b&a=c") |> equal true  
+
     ]
 
   ]

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -9,7 +9,7 @@ open Util
 
 let URL = Node.Api.URL
 
-let makeUrl input (b:string) :Node.Url.URL = URL.Create(input, !^b)
+let makeUrl input (b:string) :Node.Url.URL = URL.Create(input, b)
 
 let tests : Test = 
   testList "Url" [
@@ -243,7 +243,7 @@ let tests : Test =
 
       testCase "new" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://example.org/?a=b")          
-          let newSearchParams  : Node.Url.URLSearchParams = Node.Api.URLSearchParams.Create(!^url.searchParams)
+          let newSearchParams  : Node.Url.URLSearchParams = Node.Api.URLSearchParams.Create(url.searchParams)
           newSearchParams.append("a","c")
           (url.href = "https://example.org/?a=b" 
             && newSearchParams.toString() = "a=b&a=c") |> equal true  

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -1,0 +1,165 @@
+module Tests.Url
+
+open System
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.DynamicExtensions
+open Node.OS
+open Util
+
+let URL = Node.Api.URL
+
+let makeUrl input (b:string) :Node.Url.Url<string> = URL.Create(input, !^b)
+
+let tests : Test = 
+  testList "Url" [
+  
+    testList "new" [
+      testCase "from string" <| fun _ ->
+          let url = makeUrl "/foo" "https://example.org/"
+          url.href = "https://example.org/foo" |> equal true
+
+      testCase "unicode" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://測試")
+          (url.href = "https://xn--g6w251d/" // with node compiled with ICU enabled
+            || url.href = "https://測試") |> equal true
+    ]
+
+    testList "hash" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo#bar")
+          url.hash = "#bar" |> equal true
+      
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo#bar")
+          url.hash <- "baz"
+          url.href = "https://example.org/foo#baz" |> equal true
+    ]
+
+    testList "host" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          url.host = "example.org:81" |> equal true
+      
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          url.host <- "example.com:82"
+          url.href = "https://example.com:82/foo" |> equal true
+    ]
+
+    testList "hostname" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          url.hostname = "example.org" |> equal true
+      
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:81/foo")
+          url.hostname <- "example.com:82"
+          url.href = "https://example.com:81/foo" |> equal true
+    ]
+
+    testList "href" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo")
+          url.href = "https://example.org/foo" |> equal true
+      
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/bar")
+          url.href <- "https://example.org/foo"
+          url.href = "https://example.org/foo" |> equal true
+    ]
+
+    testList "origin" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/foo/bar?baz")
+          url.origin = "https://example.org" |> equal true
+      
+      testCase "unicode" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://測試")
+          url.origin = "https://xn--g6w251d" |> equal true
+    ]
+
+    testList "password" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          url.password = "xyz" |> equal true
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          url.password <- "123" 
+          url.href = "https://abc:123@example.com/" |> equal true  
+    ]
+
+    testList "pathname" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc/xyz?123")
+          url.pathname = "/abc/xyz" |> equal true
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc/xyz?123")
+          url.pathname <- "/abcdef" 
+          url.href = "https://example.org/abcdef?123" |> equal true  
+    ]
+
+    testList "port" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          url.port = "8888" |> equal true
+
+      testCase "443" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          url.port <- "443"
+          (url.port = "" && url.href = "https://example.org/") |> equal true  
+
+      testCase "1234" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          url.port <- "1234"
+          (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
+
+      testCase "abcd" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          url.port <- "1234"
+          url.port <- "abcd"
+          (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
+
+      testCase "abcd" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org:8888")
+          url.port <- "1234.5678"
+          (url.port = "1234" && url.href = "https://example.org:1234/") |> equal true  
+    ]
+
+    testList "protocol" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org")
+          url.protocol = "https:" |> equal true
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org")
+          url.protocol <- "ftp"
+          url.href = "ftp://example.org/" |> equal true  
+    ]
+
+    testList "search" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc?123")
+          url.search = "?123" |> equal true
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://example.org/abc?123")
+          url.search = "?123" |> equal true
+          url.search <- "abc=xyz"
+          url.href = "https://example.org/abc?abc=xyz" |> equal true  
+    ]
+
+    testList "username" [
+      testCase "get" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          url.username = "abc" |> equal true
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.Url<string> = URL.Create("https://abc:xyz@example.com")
+          url.username <- "123" 
+          url.href = "https://123:xyz@example.com/" |> equal true  
+    ]
+
+  ]

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -172,10 +172,9 @@ let tests : Test =
           else
             Node.Url.Static.fileURLToPath "file:///C:/path/" = """C:/path/""" |> equal true
 
-      
       (*
       testCase "format" <| fun _ ->
-//          let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
+          let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
           let formatOptions = jsOptions<Node.Url.IFormatOptions>( fun o -> 
             o.fragment <- Some false
             o.unicode <- Some true
@@ -188,10 +187,12 @@ let tests : Test =
               "unicode" ==> true
               "auth" ==> false
             ]
-          printfn "format: %s" (Node.Url.Static.format("https://a:b@測試?abc#foo",formatOptions))
-          Node.Url.Static.format("https://a:b@測試?abc#foo",!!test) = "https://測試/?abc" |> equal true
-//          Node.Url.Static.format(url,formatOptions) = "https://測試/?abc" |> equal true
-        *)
+            
+          printfn "format: %s" (Node.Url.Static.format(url,formatOptions))
+//          printfn "format: %s" (Node.Url.Static.format("https://a:b@測試?abc#foo",formatOptions))
+//          Node.Url.Static.format("https://a:b@測試?abc#foo",!!test) = "https://測試/?abc" |> equal true
+          Node.Url.Static.format(url,formatOptions) = "https://測試/?abc" |> equal true
+          *)
     ]
 
     testList "URLSearchParams" [

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -172,7 +172,6 @@ let tests : Test =
           else
             Node.Url.Static.fileURLToPath "file:///C:/path/" = """C:/path/""" |> equal true
 
-      (*
       testCase "format" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://a:b@測試?abc#foo")
           let formatOptions = jsOptions<Node.Url.IFormatOptions>( fun o -> 
@@ -181,19 +180,24 @@ let tests : Test =
             o.auth <- Some false
             o.search <- Some true
           )
-          let test = 
-            createObj [
-              "fragment" ==> false
-              "unicode" ==> true
-              "auth" ==> false
-            ]
-            
-          printfn "format: %s" (Node.Url.Static.format(url,formatOptions))
-//          printfn "format: %s" (Node.Url.Static.format("https://a:b@測試?abc#foo",formatOptions))
-//          Node.Url.Static.format("https://a:b@測試?abc#foo",!!test) = "https://測試/?abc" |> equal true
-          Node.Url.Static.format(url,formatOptions) = "https://測試/?abc" |> equal true
-          *)
-    ]
+          printfn "format: %s" (URL.format(url,formatOptions))
+          URL.format(url,formatOptions) = "https://測試/?abc" |> equal true
+
+      testCase "format Legacy" <| fun _ ->
+          let url = Node.Api.URL
+          let legacyOptions =
+              jsOptions<Node.Url.LegacyFormatOptions>(fun o ->
+                  o.protocol <- "https"
+                  o.hostname <- "example.com"
+                  o.pathname <- "/some/path"
+                  o.query <- createObj [
+                      "page" ==> 1
+                      "format" ==> "json"
+                  ]
+              )
+          printfn "format: %s" (url.format(legacyOptions))
+          url.format(legacyOptions) = "https://example.com/some/path?page=1&format=json" |> equal true
+      ]
 
     testList "URLSearchParams" [
       testCase "get" <| fun _ ->

--- a/tests/Util.fs
+++ b/tests/Util.fs
@@ -1,0 +1,24 @@
+module Tests.Util
+
+open System
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.Testing
+open Node.OS
+
+let testList (name : string) (tests: seq<'b>) = name, tests
+let testCase (msg : string) (test : obj -> unit) = msg, test
+
+let equal expected actual: unit =
+    Assert.AreEqual(actual, expected)
+
+type Test = string * seq<string * seq<string * (obj -> unit)>>        
+
+let isPosix = 
+  let p = Node.Api.``process``.platform
+  match p with 
+  | Node.Base.Platform.Win32 -> false
+  | _ -> true
+
+let testPassed() = true |> equal true
+let testFailed() = false |> equal true

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,2 @@
+const os = require('os');
+console.log( os.networkInterfaces() );

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,2 +1,0 @@
-const os = require('os');
-console.log( os.networkInterfaces() );


### PR DESCRIPTION
Since the Node.js and browser use the WHATWG API I tried to make things compatible with the current Borwser DOM API.

Needs testing on posix. For info, tests pass using Node.js LTS 10.15.3.

Note: One static function in the Url api, format, does not work while in js it's ok. So I guess my implementation is not good. I've prepared a test in tests/Url.fs. If you could check that would be good.

Next question: do we want to support legacy?