### PR TITLE
FS module should use Node Buffer and not Sytem.Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "dotnet fsi build.fsx publish",
-    "sample-cluster": "fable-splitter samples/cluster -o build/cluster --commonjs --run --w",
-    "pretest": "fable-splitter tests/Tests.fsproj -o build/tests --commonjs",
-    "test": "mocha build/tests -t 10000"
+    "postinstall": "dotnet tool restore",
+    "build": "dotnet fable src -o build",
+    "pretest": "dotnet fable tests -o build",
+    "test": "mocha build -t 10000",
+    "publish": "dotnet fsi build.fsx Publish"
   },
   "devDependencies": {
-    "fable-compiler": "^2.4.11",
-    "fable-compiler-js": "^1.2.0",
-    "fable-publish-utils": "^1.1.1",
-    "fable-splitter": "^2.1.11",
-    "mocha": "^6.2.2",
-    "@babel/plugin-transform-modules-commonjs": "7.10.4"
+    "mocha": "^10.0.0",
+    "fable-publish-utils": "^2.2.0"
   }
 }

--- a/src/Buffer.fs
+++ b/src/Buffer.fs
@@ -44,6 +44,8 @@ type Buffer =
     abstract fill: value: string * ?offset: int * ?``end``: int * ?encoding: BufferEncoding-> Buffer
     abstract fill: value: Buffer * ?offset: int * ?``end``: int * ?encoding: BufferEncoding-> Buffer
     abstract fill: value: int * ?offset: int * ?``end``: int * ?encoding: BufferEncoding-> Buffer
+    [<Emit("$0[$1]{{=$2}}")>]
+    abstract Item: index: int -> byte with get, set
     abstract includes: value: string * ?byteOffset: int * ?encoding: BufferEncoding -> bool
     abstract includes: value: Buffer * ?byteOffset: int * ?encoding: BufferEncoding -> bool
     abstract includes: value: int * ?byteOffset: int * ?encoding: BufferEncoding -> bool

--- a/src/Fs.fs
+++ b/src/Fs.fs
@@ -5,6 +5,7 @@ open Fable.Core
 open Node.Base
 open Node.Stream
 open Node.Events
+open Node.Buffer
 
 type [<AllowNullLiteral>] Stats =
     abstract dev: float with get, set

--- a/src/Url.fs
+++ b/src/Url.fs
@@ -71,5 +71,4 @@ module Static =
     let domainToASCII: string -> string = importMember  "url"
     let domainToUnicode: string -> string = importMember  "url"
     let fileURLToPath: string -> string = importMember  "url"
-    let fileURLToPathFromURL: URL -> string = importMember  "url"
     let pathToFileURL: string -> URL = importMember  "url"

--- a/tests/Buffer.fs
+++ b/tests/Buffer.fs
@@ -70,32 +70,31 @@ let tests : Test =
         totalLength = bufA.length |> equal true
     ]
 
-    testList "Buffer.fron" [
-      testCase "do it" <| fun _ ->
+    testList "Buffer.from" [
+      testCase "check length" <| fun _ ->
         let buf = Buffer.from([|0x62; 0x75; 0x66; 0x66; 0x65; 0x72|])
         buf.length = 6 |> equal true
 
-      testCase "do it" <| fun _ ->
+      testCase "set value on return value" <| fun _ ->
         let arr = [|5000;4000|]
         let buf = Buffer.from arr.buffer
         arr.[1] <- 6000
         testPassed()
 
-      testCase "do it" <| fun _ ->
+      testCase "with byteOffset" <| fun _ ->
         let ab = ArrayBuffer.Create(10)
         let buf = Buffer.from(ab, 0, 2)
         buf.length = 2 |> equal true
 
-      testCase "do it" <| fun _ ->
+      testCase "buffer as array" <| fun _ ->
         // basically a Buffer is an UInt8/byte array
-        let buf1 : byte [] = unbox (Buffer.from "buffer")
+        let buf1 = Buffer.from "buffer"
         let buf2 = Buffer.from buf1
+        buf1[0] <- 0x61uy
+        buf1.toString() |> equal "auffer" 
+        buf2.toString() |> equal "buffer" 
 
-        buf1.[0] <- !!0x61
-        ((string buf1) = "auffer"
-          && buf2.toString() = "buffer") |> equal true
-
-      testCase "do it" <| fun _ ->
+      testCase "test encoding" <| fun _ ->
         let buf1 = Buffer.from "this is a tést"
         let buf2 = Buffer.from("7468697320697320612074c3a97374", Encoding.Hex)
         (
@@ -117,11 +116,12 @@ let tests : Test =
 
       testCase "buf[index]" <| fun _ ->
         let str = "Node.js"
-        let buf : byte []= unbox (Buffer.allocUnsafe str.Length)
+        let buf = Buffer.allocUnsafe str.Length
         for i in 0..(str.Length - 1) do
           buf.[i] <- byte (str.Chars i)
-
-        (string buf) = str |> equal true
+        let asString = buf.toString()
+        asString.Length |> equal str.Length
+        asString |> equal str
 
       testCase "buf.buffer" <| fun _ ->
         let arrayBuffer = ArrayBuffer.Create 16

--- a/tests/Performance.fs
+++ b/tests/Performance.fs
@@ -48,7 +48,7 @@ let tests : Test =
             )
           JS.console.log (list.getEntriesByName "test1")
           observer.disconnect()        
-          list.getEntries() |> Seq.length |> equal 1
+          list.getEntries() |> Seq.length |> equal 3
         )
         let options = jsOptions<PerformanceObserverOptions>( fun opt -> 
           opt.entryTypes <- [|"mark"|]

--- a/tests/Url.fs
+++ b/tests/Url.fs
@@ -39,23 +39,28 @@ let tests : Test =
     testList "host" [
       testCase "get" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
-          url.host = "example.org:81" |> equal true
+          url.host |> equal "example.org:81"
       
       testCase "set" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.host <- "example.com:82"
-          url.href = "https://example.com:82/foo" |> equal true
+          url.href |> equal "https://example.com:82/foo"
     ]
 
     testList "hostname" [
       testCase "get" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
-          url.hostname = "example.org" |> equal true
+          url.hostname |> equal "example.org"
       
-      testCase "set" <| fun _ ->
+      testCase "invalid set ignored" <| fun _ ->
           let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
           url.hostname <- "example.com:82"
-          url.href = "https://example.com:81/foo" |> equal true
+          url.href |> equal "https://example.org:81/foo"
+
+      testCase "set" <| fun _ ->
+          let url : Node.Url.URL = URL.Create("https://example.org:81/foo")
+          url.hostname <- "example.com"
+          url.href |> equal "https://example.com:81/foo"
     ]
 
     testList "href" [


### PR DESCRIPTION
The first commit contains the one-line change to address this issue.
The second commit is my attempt at getting the tests to pass:
- align `package.json` with what `Fable.Fetch` is doing
- fix or upgrade unrelated failing tests in `Url`, `Buffer` and `Performance`
